### PR TITLE
changed sequelize invoke comamnd to use npx

### DIFF
--- a/src/signup/signup_dataprovider.js
+++ b/src/signup/signup_dataprovider.js
@@ -27,10 +27,10 @@ let SignupDataProvider = {
     let connectionString = `${config.dialect}://${config.username}:${config.password}@${config.host}/tenant_${accountId}`;
 
     logger.info(`Create Database for Tenant[Name: tenant_${accountId}]`);
-    await cli.executeCommand(`node_modules/.bin/sequelize db:create --url ${connectionString}`);
+    await cli.executeCommand(`npx sequelize db:create --url ${connectionString}`);
 
     logger.info(`Run Migrations on Tenant Database[Name: tenant_${accountId}]`);
-    await cli.executeCommand(`node_modules/.bin/sequelize db:migrate --url ${connectionString} --migrations-path=${migrationPath}`);
+    await cli.executeCommand(`npx sequelize db:migrate --url ${connectionString} --migrations-path=${migrationPath}`);
   
     dbConnector.addSequelizeConnectionToRepo(dbRepo, `tenant_${accountId}`);
   },


### PR DESCRIPTION
Hi, I was getting the following response when invoking ```/api/v1/accounts/signup```

```
{
    "status": "error",
    "data": "Command failed: node_modules/.bin/sequelize db:create --url mysql://root:my_password@127.0.0.1/tenant_5\n'node_modules' is not recognized as an internal or external command,\r\noperable program or batch file.\r\n",
    "message": "Something went wrong!!! Please try again later."
}
```

Thought using npx to run the migration would be better.